### PR TITLE
65 navigation without the page being refreshed

### DIFF
--- a/app/src/androidTest/kotlin/com/platform/platform/openemoji/navigation/NavigationTest.kt
+++ b/app/src/androidTest/kotlin/com/platform/platform/openemoji/navigation/NavigationTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
 import com.platform.openemoji.emoji.Emoji
 import com.platform.openemoji.emoji.catalogue.EmojiCatalogue
 import com.platform.openemoji.navigation.Navigation
@@ -42,6 +43,29 @@ class NavigationTest {
             .performClick()
         composeTestRule.onNodeWithTag("emojiDetailScreen").assertExists()
         // Test that it's the correct emoji details screen.
-        composeTestRule.onNodeWithText("a")
+        composeTestRule.onNodeWithText("a").assertExists()
+    }
+
+    @Test
+    fun testNavigationStatePreservation() {
+        composeTestRule.setContent {
+            Navigation()
+        }
+
+        // Make sure we're in the search screen.
+        composeTestRule.onNodeWithTag("bottomNavigationBarSearch")
+            .performClick()
+
+        // Perform search to bring the screen into a state we can test the preservation of.
+        composeTestRule.onNodeWithTag("searchTextField")
+            .performTextInput("h")
+        composeTestRule.onNodeWithText("Search results for: h").assertExists()
+
+        // Go to home screen and back, and test that it's still in a search state.
+        composeTestRule.onNodeWithTag("bottomNavigationBarHome")
+            .performClick()
+        composeTestRule.onNodeWithTag("bottomNavigationBarSearch")
+            .performClick()
+        composeTestRule.onNodeWithText("Search results for: h").assertExists()
     }
 }

--- a/app/src/main/kotlin/com/platform/openemoji/emoji/category/CategoryScrollCarousel.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/emoji/category/CategoryScrollCarousel.kt
@@ -14,27 +14,24 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun CategoryScrollCarousel(
+    selectedCategory: String,
     categories: List<String>,
     onSelectCategory: (String) -> Unit,
 ) {
-    val selectedCategory = remember { mutableStateOf(categories[0]) }
     Column {
         LazyRow(
             modifier = Modifier.padding(vertical = 8.dp),
         ) {
             items(categories.size) { index ->
                 val category = categories[index]
-                val isSelected = selectedCategory.value == category
+                val isSelected = selectedCategory == category
                 Button(
                     onClick = {
-                        selectedCategory.value = category
                         onSelectCategory(category)
                     },
                     modifier =

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
@@ -40,6 +40,7 @@ fun BottomNavigationBar(navController: NavController) {
                     restoreState = true
                 }
             },
+            modifier = Modifier.testTag("bottomNavigationBarHome"),
         )
         NavigationBarItem(
             selected = selectedItem == stringResource(R.string.search),

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
@@ -29,7 +29,17 @@ fun BottomNavigationBar(navController: NavController) {
                     contentDescription = stringResource(R.string.home_icon_description),
                 )
             },
-            onClick = { navController.navigate(Screen.HomeScreen.route) },
+            onClick = {
+                navController.navigate(Screen.HomeScreen.route) {
+                    navController.graph.startDestinationRoute?.let { route ->
+                        popUpTo(route) {
+                            saveState = true
+                        }
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            },
         )
         NavigationBarItem(
             selected = selectedItem == stringResource(R.string.search),
@@ -42,7 +52,17 @@ fun BottomNavigationBar(navController: NavController) {
                     contentDescription = stringResource(R.string.search_icon_description),
                 )
             },
-            onClick = { navController.navigate(Screen.SearchScreen.route) },
+            onClick = {
+                navController.navigate(Screen.SearchScreen.route) {
+                    navController.graph.startDestinationRoute?.let { route ->
+                        popUpTo(route) {
+                            saveState = true
+                        }
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            },
             modifier = Modifier.testTag("bottomNavigationBarSearch"),
         )
     }

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BottomNavigationBar.kt
@@ -8,6 +8,9 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -15,21 +18,28 @@ import androidx.navigation.NavController
 import com.platform.openemoji.R
 
 @Composable
-fun BottomNavigationBar(navController: NavController) {
-    val selectedItem = navController.currentBackStackEntry?.destination?.route
+fun BottomNavigationBar(
+    navController: NavController,
+    startDestination: String,
+) {
     NavigationBar {
+        val selectedRootScreen = remember { mutableStateOf(startDestination) }
         NavigationBarItem(
-            selected = selectedItem == stringResource(R.string.home),
+            selected = selectedRootScreen.value == Screen.HomeScreen.route,
             label = {
                 Text(stringResource(R.string.home))
             },
             icon = {
                 Icon(
                     Icons.Filled.Home,
-                    contentDescription = stringResource(R.string.home_icon_description),
+                    contentDescription =
+                        stringResource(
+                            R.string.home_icon_description,
+                        ),
                 )
             },
             onClick = {
+                selectedRootScreen.value = Screen.HomeScreen.route
                 navController.navigate(Screen.HomeScreen.route) {
                     navController.graph.startDestinationRoute?.let { route ->
                         popUpTo(route) {
@@ -43,7 +53,7 @@ fun BottomNavigationBar(navController: NavController) {
             modifier = Modifier.testTag("bottomNavigationBarHome"),
         )
         NavigationBarItem(
-            selected = selectedItem == stringResource(R.string.search),
+            selected = selectedRootScreen.value == Screen.SearchScreen.route,
             label = {
                 Text(stringResource(R.string.search))
             },
@@ -54,6 +64,7 @@ fun BottomNavigationBar(navController: NavController) {
                 )
             },
             onClick = {
+                selectedRootScreen.value = Screen.SearchScreen.route
                 navController.navigate(Screen.SearchScreen.route) {
                     navController.graph.startDestinationRoute?.let { route ->
                         popUpTo(route) {

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/Navigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/Navigation.kt
@@ -24,9 +24,10 @@ fun Navigation() {
     val emojiCatalogue = EmojiCatalogue.get()
 
     val navController = rememberNavController()
+    val startDestination = Screen.SearchScreen.route
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        bottomBar = { BottomNavigationBar(navController) },
+        bottomBar = { BottomNavigationBar(navController, startDestination) },
     ) { paddingValues ->
         Surface(
             modifier = Modifier.padding(paddingValues),
@@ -34,7 +35,7 @@ fun Navigation() {
         ) {
             NavHost(
                 navController = navController,
-                startDestination = Screen.SearchScreen.route,
+                startDestination = startDestination,
             ) {
                 /**
                  * Routing for SearchScreen

--- a/app/src/main/kotlin/com/platform/openemoji/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/SearchScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -24,8 +24,8 @@ import com.platform.openemoji.search.SearchField
 fun SearchScreen(navController: NavController) {
     val emojiCatalogue = EmojiCatalogue.get()
     val overview = stringResource(R.string.overview)
-    val searchQuery = remember { mutableStateOf("") }
-    val selectedCategory = remember { mutableStateOf(overview) }
+    val searchQuery = rememberSaveable { mutableStateOf("") }
+    val selectedCategory = rememberSaveable { mutableStateOf(overview) }
 
     Column {
         SearchField(searchQuery.value) { searchQuery.value = it }
@@ -49,6 +49,7 @@ fun SearchScreen(navController: NavController) {
             }
         } else {
             CategoryScrollCarousel(
+                selectedCategory.value,
                 listOf(overview) + emojiCatalogue.categories,
             ) { selectedCategory.value = it }
             EmojiCatalogueUi(


### PR DESCRIPTION
- The search screen is no longer refreshed when navigated away from and back.  
- Could also be implemented, instead of using "rememberSaveable", with ViewModel. That's supposed to be better, but I wasn't convinced that it would be for our simple screens. I think it should be used if we later on decide to learn and use ViewModels for everything. It seems a little silly though; a bit like using react hooks to move all state and state-changing logic away from the UI.  
- Also tested the preservation of search state between navigation.
- My implementation won't automatically work for any new screens and their state; they need to use rememberSaveable, and navigation needs to be done the same way as done here in the BottomNavigationBar.

closes #65 