### PR TITLE
83 convert show more clickable text to component

### DIFF
--- a/app/src/main/kotlin/com/platform/openemoji/events/UpcomingEvents.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/events/UpcomingEvents.kt
@@ -45,7 +45,11 @@ fun UpcomingEvents(navController: NavController) {
                 text = stringResource(R.string.upcoming_events),
                 style = MaterialTheme.typography.titleLarge,
             )
-            ShowMoreNavigation(navController, Screen.EventListScreen)
+            ShowMoreNavigation(
+                navController = navController,
+                screen = Screen.EventListScreen,
+                modifier = Modifier.testTag("showMoreEvents"),
+            )
         }
         // TODO: Replace with real event data
         EventCard(event)

--- a/app/src/main/kotlin/com/platform/openemoji/events/UpcomingEvents.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/events/UpcomingEvents.kt
@@ -1,6 +1,5 @@
 package com.platform.openemoji.events
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,11 +12,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.platform.openemoji.R
 import com.platform.openemoji.navigation.Screen
+import com.platform.openemoji.navigation.ShowMoreNavigation
 
 @Composable
 fun UpcomingEvents(navController: NavController) {
@@ -46,18 +45,7 @@ fun UpcomingEvents(navController: NavController) {
                 text = stringResource(R.string.upcoming_events),
                 style = MaterialTheme.typography.titleLarge,
             )
-
-            Text(
-                text = stringResource(R.string.show_more),
-                color = MaterialTheme.colorScheme.primary,
-                textDecoration = TextDecoration.Underline,
-                modifier =
-                    Modifier.clickable {
-                        navController.navigate(
-                            Screen.EventListScreen.route,
-                        )
-                    }.testTag("showMoreEvents"),
-            )
+            ShowMoreNavigation(navController, Screen.EventListScreen)
         }
         // TODO: Replace with real event data
         EventCard(event)

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
@@ -15,13 +15,16 @@ import androidx.navigation.NavController
 import com.platform.openemoji.R
 
 @Composable
-fun BackButtonNavigation(navController: NavController) {
+fun BackButtonNavigation(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+) {
     IconButton(onClick = { navController.popBackStack() }) {
         Icon(
             Icons.Filled.ArrowBack,
             contentDescription = stringResource(R.string.back_arrow),
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(48.dp).testTag("eventListBackButton"),
+            modifier = modifier.size(48.dp).testTag("eventListBackButton"),
         )
     }
 }

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
@@ -1,0 +1,27 @@
+package com.platform.openemoji.navigation
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.platform.openemoji.R
+
+@Composable
+fun BackButtonNavigation(navController: NavController) {
+    IconButton(onClick = { navController.popBackStack() }) {
+        Icon(
+            Icons.Filled.ArrowBack,
+            contentDescription = stringResource(R.string.back_arrow),
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(48.dp).testTag("eventListBackButton"),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/ShowMoreNavigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/ShowMoreNavigation.kt
@@ -1,0 +1,29 @@
+package com.platform.openemoji.navigation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.navigation.NavController
+import com.platform.openemoji.R
+
+@Composable
+fun ShowMoreNavigation(
+    navController: NavController,
+    screen: Screen,
+) {
+    Text(
+        text = stringResource(R.string.show_more),
+        color = MaterialTheme.colorScheme.primary,
+        textDecoration = TextDecoration.Underline,
+        modifier =
+            Modifier.clickable {
+                navController.navigate(
+                    screen.route,
+                )
+            },
+    )
+}

--- a/app/src/main/kotlin/com/platform/openemoji/navigation/ShowMoreNavigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/ShowMoreNavigation.kt
@@ -14,13 +14,14 @@ import com.platform.openemoji.R
 fun ShowMoreNavigation(
     navController: NavController,
     screen: Screen,
+    modifier: Modifier = Modifier,
 ) {
     Text(
         text = stringResource(R.string.show_more),
         color = MaterialTheme.colorScheme.primary,
         textDecoration = TextDecoration.Underline,
         modifier =
-            Modifier.clickable {
+            modifier.clickable {
                 navController.navigate(
                     screen.route,
                 )

--- a/app/src/main/kotlin/com/platform/openemoji/news/LatestNews.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/news/LatestNews.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -58,7 +59,11 @@ fun LatestNews(navController: NavController) {
                 text = stringResource(R.string.latest_news),
                 style = MaterialTheme.typography.titleLarge,
             )
-            ShowMoreNavigation(navController, Screen.NewsListScreen)
+            ShowMoreNavigation(
+                navController = navController,
+                screen = Screen.NewsListScreen,
+                modifier = Modifier.testTag("showMoreLatestNews"),
+            )
         }
         for (news in latestNewsData) {
             NewsCard(news)

--- a/app/src/main/kotlin/com/platform/openemoji/news/LatestNews.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/news/LatestNews.kt
@@ -1,6 +1,5 @@
 package com.platform.openemoji.news
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,11 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.platform.openemoji.R
 import com.platform.openemoji.navigation.Screen
+import com.platform.openemoji.navigation.ShowMoreNavigation
 
 @Composable
 fun LatestNews(navController: NavController) {
@@ -59,18 +58,7 @@ fun LatestNews(navController: NavController) {
                 text = stringResource(R.string.latest_news),
                 style = MaterialTheme.typography.titleLarge,
             )
-
-            Text(
-                text = stringResource(R.string.show_more),
-                color = MaterialTheme.colorScheme.primary,
-                textDecoration = TextDecoration.Underline,
-                modifier =
-                    Modifier.clickable {
-                        navController.navigate(
-                            Screen.NewsListScreen.route,
-                        )
-                    },
-            )
+            ShowMoreNavigation(navController, Screen.NewsListScreen)
         }
         for (news in latestNewsData) {
             NewsCard(news)

--- a/app/src/main/kotlin/com/platform/openemoji/screens/EmojiDetailScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/EmojiDetailScreen.kt
@@ -6,11 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,13 +14,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.platform.openemoji.R
 import com.platform.openemoji.emoji.Emoji
 import com.platform.openemoji.emoji.IconCopy
+import com.platform.openemoji.navigation.BackButtonNavigation
 
 @Composable
 fun EmojiDetailScreen(
@@ -38,14 +33,8 @@ fun EmojiDetailScreen(
         /**
          * Arrow back button, takes you back to previous location.
          */
-        IconButton(onClick = { navController.popBackStack() }) {
-            Icon(
-                Icons.Filled.ArrowBack,
-                contentDescription = stringResource(R.string.back_arrow),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(48.dp),
-            )
-        }
+        BackButtonNavigation(navController)
+
         Card(
             modifier =
                 Modifier

--- a/app/src/main/kotlin/com/platform/openemoji/screens/EmojiDetailScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/EmojiDetailScreen.kt
@@ -33,7 +33,10 @@ fun EmojiDetailScreen(
         /**
          * Arrow back button, takes you back to previous location.
          */
-        BackButtonNavigation(navController)
+        BackButtonNavigation(
+            navController = navController,
+            modifier = Modifier.testTag("emojiDetailBackButton"),
+        )
 
         Card(
             modifier =

--- a/app/src/main/kotlin/com/platform/openemoji/screens/EventListScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/EventListScreen.kt
@@ -39,8 +39,10 @@ fun EventListScreen(navController: NavController) {
         /**
          * Arrow back button, takes you back to previous location.
          */
-        BackButtonNavigation(navController)
-
+        BackButtonNavigation(
+            navController = navController,
+            modifier = Modifier.testTag("eventListBackButton"),
+        )
         Text(
             text = stringResource(R.string.eventsandtopics),
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/com/platform/openemoji/screens/EventListScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/EventListScreen.kt
@@ -2,13 +2,8 @@ package com.platform.openemoji.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,6 +16,7 @@ import androidx.navigation.NavController
 import com.platform.openemoji.R
 import com.platform.openemoji.events.Event
 import com.platform.openemoji.events.EventCard
+import com.platform.openemoji.navigation.BackButtonNavigation
 
 @Composable
 fun EventListScreen(navController: NavController) {
@@ -40,14 +36,11 @@ fun EventListScreen(navController: NavController) {
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 8.dp).testTag("eventListScreen"),
     ) {
-        IconButton(onClick = { navController.popBackStack() }) {
-            Icon(
-                Icons.Filled.ArrowBack,
-                contentDescription = stringResource(R.string.back_arrow),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(48.dp).testTag("eventListBackButton"),
-            )
-        }
+        /**
+         * Arrow back button, takes you back to previous location.
+         */
+        BackButtonNavigation(navController)
+
         Text(
             text = stringResource(R.string.eventsandtopics),
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.platform.openemoji.R
+import com.platform.openemoji.navigation.BackButtonNavigation
 import com.platform.openemoji.news.News
 import com.platform.openemoji.news.NewsCard
 
@@ -64,14 +65,11 @@ fun NewsListScreen(navController: NavController) {
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 8.dp),
     ) {
-        IconButton(onClick = { navController.popBackStack() }) {
-            Icon(
-                Icons.Filled.ArrowBack,
-                contentDescription = stringResource(R.string.back_arrow),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(48.dp),
-            )
-        }
+        /**
+         * Arrow back button, takes you back to previous location.
+         */
+        BackButtonNavigation(navController)
+
         Text(
             text = stringResource(R.string.latest_news),
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -63,8 +64,10 @@ fun NewsListScreen(navController: NavController) {
         /**
          * Arrow back button, takes you back to previous location.
          */
-        BackButtonNavigation(navController)
-
+        BackButtonNavigation(
+            navController = navController,
+            modifier = Modifier.testTag("newsListBackButton"),
+        )
         Text(
             text = stringResource(R.string.latest_news),
             modifier = Modifier.padding(12.dp),

--- a/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/screens/NewsListScreen.kt
@@ -2,13 +2,8 @@ package com.platform.openemoji.screens
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
Converted show more code and back button code into components, to avoid redundant code when used mutliple places. Now calls these navigation components instead.
Closes #83  
