### PR TITLE
105 news analytics

### DIFF
--- a/app/src/main/kotlin/com/platform/openemoji/Activity.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/Activity.kt
@@ -3,6 +3,8 @@ package com.platform.openemoji
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
 import com.amplitude.android.DefaultTrackingOptions
@@ -10,6 +12,9 @@ import com.amplitude.core.ServerZone
 import com.google.android.gms.ads.MobileAds
 import com.platform.openemoji.navigation.Navigation
 import com.platform.openemoji.theme.OpenEmojiPlatformTheme
+
+@Suppress("ktlint:standard:property-naming")
+val LocalAnalytics = compositionLocalOf<Amplitude?> { null }
 
 class Activity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,14 +28,18 @@ class Activity : ComponentActivity() {
                     context = applicationContext,
                     defaultTracking = DefaultTrackingOptions.ALL,
                     serverZone = ServerZone.EU,
-                    flushIntervalMillis = 2000,
+                    flushIntervalMillis = 10000,
                 ),
             )
+        amplitude.track("Hello")
+        amplitude.flush()
 
         MobileAds.initialize(this) {}
         setContent {
-            OpenEmojiPlatformTheme {
-                Navigation()
+            CompositionLocalProvider(LocalAnalytics provides amplitude) {
+                OpenEmojiPlatformTheme {
+                    Navigation()
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/platform/openemoji/Activity.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/Activity.kt
@@ -6,9 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import com.amplitude.android.Amplitude
-import com.amplitude.android.Configuration
-import com.amplitude.android.DefaultTrackingOptions
-import com.amplitude.core.ServerZone
 import com.google.android.gms.ads.MobileAds
 import com.platform.openemoji.navigation.Navigation
 import com.platform.openemoji.theme.OpenEmojiPlatformTheme
@@ -17,22 +14,10 @@ import com.platform.openemoji.theme.OpenEmojiPlatformTheme
 val LocalAnalytics = compositionLocalOf<Amplitude?> { null }
 
 class Activity : ComponentActivity() {
+    private var amplitude = Application.amplitude
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val amplitude =
-            Amplitude(
-                Configuration(
-                    // It's safe to expose api key
-                    // https://github.com/amplitude/Amplitude-Javascript/issues/100
-                    apiKey = "efe7c6f94fd4d20f32b6f9b91f66d6be",
-                    context = applicationContext,
-                    defaultTracking = DefaultTrackingOptions.ALL,
-                    serverZone = ServerZone.EU,
-                    flushIntervalMillis = 10000,
-                ),
-            )
-        amplitude.track("Hello")
-        amplitude.flush()
 
         MobileAds.initialize(this) {}
         setContent {

--- a/app/src/main/kotlin/com/platform/openemoji/Application.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/Application.kt
@@ -1,6 +1,10 @@
 package com.platform.openemoji
 
 import android.app.Application
+import com.amplitude.android.Amplitude
+import com.amplitude.android.Configuration
+import com.amplitude.android.DefaultTrackingOptions
+import com.amplitude.core.ServerZone
 import com.platform.openemoji.emoji.EmojiMockDataRepository
 import com.platform.openemoji.emoji.EmojiRepository
 import com.platform.openemoji.events.EventsMockDataRepository
@@ -35,5 +39,24 @@ class Application : Application(), RepositoryStore {
     }
     override val gameRepository by lazy {
         GameMockDataRepository(this, simulatedDelay = 500)
+    }
+
+    companion object {
+        lateinit var amplitude: Amplitude
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        amplitude =
+            Amplitude(
+                Configuration(
+                    // It's safe to expose api key
+                    // https://github.com/amplitude/Amplitude-Javascript/issues/100
+                    apiKey = "efe7c6f94fd4d20f32b6f9b91f66d6be",
+                    context = applicationContext,
+                    defaultTracking = DefaultTrackingOptions.ALL,
+                    serverZone = ServerZone.EU,
+                ),
+            )
     }
 }

--- a/app/src/main/kotlin/com/platform/openemoji/news/NewsCard.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/news/NewsCard.kt
@@ -26,11 +26,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.platform.openemoji.LocalAnalytics
 
 @Composable
 fun NewsCard(news: News) {
     val screenWidth = LocalConfiguration.current.screenWidthDp.dp
     val context = LocalContext.current
+    val analytics = LocalAnalytics.current
     val newsIntent = remember { Intent(Intent.ACTION_VIEW, Uri.parse(news.url)) }
 
     Card(
@@ -41,7 +43,13 @@ fun NewsCard(news: News) {
                 .padding(horizontal = 12.dp, vertical = 8.dp)
                 .testTag("newsCard")
                 .clickable {
-                    context.startActivity(newsIntent)
+                    analytics?.track(
+                        "PressedNewsCard",
+                        mapOf("name" to news.name)
+                    )
+                    if (analytics == null) {
+                        context.startActivity(newsIntent)
+                    }
                 },
     ) {
         Column(

--- a/app/src/main/kotlin/com/platform/openemoji/news/NewsCard.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/news/NewsCard.kt
@@ -45,11 +45,9 @@ fun NewsCard(news: News) {
                 .clickable {
                     analytics?.track(
                         "PressedNewsCard",
-                        mapOf("name" to news.name)
+                        mapOf("name" to news.name),
                     )
-                    if (analytics == null) {
-                        context.startActivity(newsIntent)
-                    }
+                    context.startActivity(newsIntent)
                 },
     ) {
         Column(


### PR DESCRIPTION
Why provide analytics through LocalAnalytics and also globally from Application? It's so that analytics is null in components during tests.
![image](https://github.com/ITP2-G15/OpenEmojiPlatform/assets/89947900/7f4a308d-7c29-4a84-a1a3-e6e04d3cf1f0)
