### PR TITLE
122 fix navigation bug when spamming return button from emojidetailsscreen

### DIFF
--- a/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
+++ b/app/src/main/kotlin/com/platform/openemoji/navigation/BackButtonNavigation.kt
@@ -8,6 +8,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -21,9 +25,19 @@ fun BackButtonNavigation(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
+    // Track if a navigation is in progress (to prevent multiple pops of backstack)
+    // NOTE: Since this is a composable, it will reset on page reloads and when
+    // navigation is complete.
+    var navigationInProgress by rememberSaveable { mutableStateOf(false) }
+
     IconButton(onClick = {
-        navController.popBackStack()
-        onClick()
+        // Check if a navigation is already in progress
+        if (!navigationInProgress) {
+            // If not, pop the back stack and set navigationInProgress to true
+            navController.popBackStack()
+            navigationInProgress = true
+            onClick()
+        }
     }) {
         Icon(
             Icons.AutoMirrored.Default.ArrowBack,


### PR DESCRIPTION
This will fix the bug which pops back stack multiple times when spamming back button. 
NOTE: There are multiple ways to fix this issue, was not certain which to go for, so went with the one I felt was more suitable. If this turns out to be a wrong choice in the future, we can always change it.
Fixes issue #122 